### PR TITLE
Add prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Requires Python 3.8 or higher.
    ```
 3. Füge deine Keyword-Phrasen in das Textfeld ein. Die App zeigt die Wörter nach Häufigkeit sortiert an.
 
+   Optional kannst du im Feld "Präfix vor jedem Keyword" einen Text eingeben,
+   der vor jedes ausgegebene Wort gesetzt wird.
+
 4. Über den Button "Ergebnis herunterladen" kannst du die Liste als `wortliste.txt` speichern.
 
 ## License

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -11,6 +11,12 @@ st.title("Keyword Wortzähler")
 st.write("Füge deine Keyword-Phrasen unten ein (eine Phrase pro Zeile):")
 phrases_input = st.text_area("Phrasen", height=200)
 
+# Optional prefix to put in front of each keyword in the result
+prefix = st.text_input(
+    "Präfix vor jedem Keyword (optional)",
+    value="",
+)
+
 if phrases_input:
     # Convert all phrases into individual words
 
@@ -32,7 +38,7 @@ if phrases_input:
     sorted_words = sorted(word_counts.items(), key=lambda x: x[1], reverse=True)
 
     # Prepare the text for display
-    result_lines = [f"{word} ({count})" for word, count in sorted_words]
+    result_lines = [f"{prefix}{word} ({count})" for word, count in sorted_words]
     result_text = "\n".join(result_lines)
 
     st.write("**Wörter nach Häufigkeit:**")


### PR DESCRIPTION
## Summary
- allow the user to specify a prefix for every word in the result
- document the new optional prefix field

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_b_68595768cbd8832ca6662300342b07cf