### PR TITLE
Fix for missing experimental_rerun

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,12 @@ Requires Python 3.8 or higher.
    ```
 3. Füge deine Keyword-Phrasen in das Textfeld ein. Die App zeigt die Wörter nach Häufigkeit sortiert an.
 
-   Optional kannst du im Feld "Präfix vor jedem Keyword" einen Text eingeben,
-   der vor jedes ausgegebene Wort gesetzt wird.
+    Optional kannst du im Feld "Präfix vor jedem Keyword" einen Text eingeben,
+    der vor jedes ausgegebene Wort gesetzt wird.
+
+    Nach der Berechnung kannst du über den Button "Zahlen entfernen" die
+    Häufigkeiten aus dem Ergebnis entfernen. Mit "Fenster zurücksetzen" löschst du
+    alle Eingaben.
 
 4. Über den Button "Ergebnis herunterladen" kannst du die Liste als `wortliste.txt` speichern.
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -9,26 +9,28 @@ st.title("Keyword Wortzähler")
 
 # Show an input area for phrases, one per line
 st.write("Füge deine Keyword-Phrasen unten ein (eine Phrase pro Zeile):")
-phrases_input = st.text_area("Phrasen", height=200)
+phrases_input = st.text_area("Phrasen", height=200, key="phrases_input")
 
 # Optional prefix to put in front of each keyword in the result
 prefix = st.text_input(
     "Präfix vor jedem Keyword (optional)",
     value="",
+    key="prefix",
 )
+
+if st.button("Fenster zurücksetzen"):
+    st.session_state.phrases_input = ""
+    st.session_state.prefix = ""
+    st.session_state.hide_counts = False
+
+if "hide_counts" not in st.session_state:
+    st.session_state.hide_counts = False
 
 if phrases_input:
     # Convert all phrases into individual words
-
-    # Split input into lines and extract words using regex
-
     words = []
     for line in phrases_input.splitlines():
-
         line_words = re.findall(r"\b\w+\b", line.lower())
-
-        line_words = [w.lower() for w in line.split()]
-
         words.extend(line_words)
 
     # Count how often each word appears
@@ -37,12 +39,22 @@ if phrases_input:
     # Sort words by frequency in descending order
     sorted_words = sorted(word_counts.items(), key=lambda x: x[1], reverse=True)
 
-    # Prepare the text for display
-    result_lines = [f"{prefix}{word} ({count})" for word, count in sorted_words]
-    result_text = "\n".join(result_lines)
+    # Prepare the text for display with and without counts
+    with_counts = [f"{prefix}{word} ({count})" for word, count in sorted_words]
+    without_counts = [f"{prefix}{word}" for word, _ in sorted_words]
+
+    if st.session_state.hide_counts:
+        result_text = "\n".join(without_counts)
+    else:
+        result_text = "\n".join(with_counts)
 
     st.write("**Wörter nach Häufigkeit:**")
-    st.text_area("Ergebnis", result_text, height=200)
+    st.text_area("Ergebnis", result_text, height=200, key="result_text")
+
+    if not st.session_state.hide_counts:
+        if st.button("Zahlen entfernen"):
+            st.session_state.hide_counts = True
+
     st.download_button(
         label="Ergebnis herunterladen",
         data=result_text,


### PR DESCRIPTION
## Summary
- reset and hide count buttons no longer use `st.experimental_rerun`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68595cad828c832c943d8d02abfa78f9